### PR TITLE
Corrected the Cisco CSR image name for the connect and remote vpc data files

### DIFF
--- a/modules/connect_vpc/data.tf
+++ b/modules/connect_vpc/data.tf
@@ -8,7 +8,7 @@ data "aws_ami" "csr" {
 
   filter {
     name   = "name"
-    values = ["cisco-CSR-.16.12.01a-BYOL*"]
+    values = ["cisco_CSR-16.09.08-BYOL*"]
   }
 
   owners = ["679593333241"] # Cisco Systems

--- a/modules/remote_vpc/data.tf
+++ b/modules/remote_vpc/data.tf
@@ -8,7 +8,7 @@ data "aws_ami" "csr" {
 
   filter {
     name   = "name"
-    values = ["cisco-CSR-.16.12.01a-BYOL*"]
+    values = ["cisco_CSR-16.09.08-BYOL*"]
   }
 
   owners = ["679593333241"] # Cisco Systems


### PR DESCRIPTION
…a files

Corrected the Cisco CSR image name in the data files in order to use the correct AMI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
