### PR TITLE
Migrate to templatefile function for instance user_data

### DIFF
--- a/modules/connect_vpc/csr.tf
+++ b/modules/connect_vpc/csr.tf
@@ -3,10 +3,8 @@
 
 # --- modules/connect_vpc/csr.tf ---
 
-data "template_file" "csr_userdata" {
-  count    = var.vpc_info.instance_count
-  template = file("${path.root}/templates/connect_csr_boot_strap_${count.index + 1}.tpl")
-  vars = {
+locals {
+  csr_userdata = templatefile("${path.root}/templates/connect_csr_boot_strap_1.tpl", {
     hostname               = local.hostname
     cgw_tunnel_interface   = local.cgw_tunnel_interface
     cgw_tunnel_ip_address  = local.cgw_tunnel_ip_address
@@ -30,7 +28,7 @@ data "template_file" "csr_userdata" {
     tunnel_cidr_block      = local.tunnel_cidr_block
     tunnnel_cidr_mask      = local.tunnnel_cidr_mask
     vpc_router             = local.vpc_router
-  }
+  })
 }
 
 resource "aws_network_interface" "g1" {
@@ -64,7 +62,7 @@ resource "aws_instance" "csr" {
   ami           = data.aws_ami.csr.id
   instance_type = var.vpc_info.csr_instance_size
   key_name      = var.key_name
-  user_data     = data.template_file.csr_userdata[count.index].rendered
+  user_data     = local.csr_userdata
 
   network_interface {
     network_interface_id = aws_network_interface.g1.id

--- a/modules/remote_vpc/csr.tf
+++ b/modules/remote_vpc/csr.tf
@@ -3,10 +3,8 @@
 
 # --- modules/rempote_vpc/csr.tf ---
 
-data "template_file" "csr_userdata" {
-  count    = var.vpc_info.instance_count
-  template = file("${path.root}/templates/remote_csr_boot_strap_${count.index + 1}.tpl")
-  vars = {
+locals {
+  csr_userdata = templatefile("${path.root}/templates/remote_csr_boot_strap_1.tpl", {
     hostname              = local.hostname
     isakmp_secret         = local.isakmp_secret
     remote_peer_tunnel_ip = local.remote_peer_tunnel_ip
@@ -18,7 +16,7 @@ data "template_file" "csr_userdata" {
     tunnel_source_ip      = local.tunnel_source_ip
     tunnel_source_mask    = local.tunnel_source_mask
     tunnel_destination_ip = local.tunnel_destination_ip
-  }
+  })
 }
 
 resource "aws_network_interface" "g1" {
@@ -53,7 +51,7 @@ resource "aws_instance" "csr" {
   ami           = data.aws_ami.csr.id
   instance_type = var.vpc_info.csr_instance_size
   key_name      = var.key_name
-  user_data     = data.template_file.csr_userdata[count.index].rendered
+  user_data     = local.csr_userdata
 
   network_interface {
     network_interface_id = aws_network_interface.g1.id


### PR DESCRIPTION
*Issue #, if available:* #5

*Description of changes:*
Removes the deprecated `template_file` data source, which is also not supported on Apple ARM CPUs. This change replaces it with the built-in `templatefile` function. See issue notes for additional details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
